### PR TITLE
fix: correct 'Destkop' typo to 'Desktop' in App.razor.js

### DIFF
--- a/App.razor.js
+++ b/App.razor.js
@@ -1,14 +1,14 @@
 export function getOrientation() {
     if (screen.orientation.type.startsWith("portrait-")) {
         if (screen.width > 1000) {
-            return 0; // Destkop
+            return 0; // Desktop
         }
 
         return 1; // Portrait
     }
 
     if (screen.height > 1000) {
-        return 0; // Destkop
+        return 0; // Desktop
     }
 
     return 2; // Landscape


### PR DESCRIPTION
## Summary

- Fixes the misspelling of "Desktop" as "Destkop" in comments on lines 4 and 11 of `App.razor.js`

Closes #15