### PR TITLE
fix: remove commented-out JavaScript code in index.html

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -16,7 +16,7 @@
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
 
     <!-- Start Single Page Apps for GitHub Pages -->
-<!--     <script type="text/javascript">
+    <script type="text/javascript">
         // Single Page Apps for GitHub Pages
         // https://github.com/rafrex/spa-github-pages
         // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
@@ -44,7 +44,7 @@
                 }
             }
         }(window.location))
-    </script> -->
+    </script>
     <!-- End Single Page Apps for GitHub Pages -->
 </head>
 
@@ -66,16 +66,6 @@
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="sw-registrator.js"></script>
-<!--     <script>
-        window.getOrientation = (o) => {
-            return 
-        }
-
-        screen.orientation.addEventListener("change", (event) => {
-            dotNetReference.invokeMethodAsync('OrientationChanged', window.orientation);
-            console.log(`ScreenOrientation change: ${type}, ${angle} degrees.`);
-        });
-    </script> -->
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

- **Uncommented** the SPA redirect handler script (lines 19-47) so GitHub Pages routing works correctly. This script handles converting query string redirects from `404.html` back into proper URLs.
- **Removed** the broken commented-out orientation handler script (lines 69-78) which contained incomplete/non-functional code (`return` with no value, undefined `dotNetReference` variable).

## Changes

- `wwwroot/index.html`: 2 insertions, 12 deletions (net -10 lines)

Closes #13