### PR TITLE
fix: replace int.Parse with int.TryParse in Mu AddScoreDialog

### DIFF
--- a/Components/Games/Mu/AddScoreDialog.razor.cs
+++ b/Components/Games/Mu/AddScoreDialog.razor.cs
@@ -71,8 +71,11 @@ public partial class AddScoreDialog
 
     private void SetScore(string score, string playerName)
     {
-        _Points[playerName] = int.Parse(score);
-        StateHasChanged();
+        if (int.TryParse(score, out var value))
+        {
+            _Points[playerName] = value;
+            StateHasChanged();
+        }
     }
 
     private string _Chief = string.Empty;


### PR DESCRIPTION
## Summary

- Replaces `int.Parse(score)` with `int.TryParse(score, out var value)` in the `SetScore` method of `Components/Games/Mu/AddScoreDialog.razor.cs`
- Prevents `FormatException` crashes when users enter non-numeric input (empty string, letters, etc.)
- Invalid input is now silently ignored rather than crashing the dialog

Fixes #23