### PR TITLE
fix: use correct DialogParameters type in StalemateDialog

### DIFF
--- a/Pages/Games/Mu.razor.cs
+++ b/Pages/Games/Mu.razor.cs
@@ -31,7 +31,7 @@ public partial class Mu
 
     private async Task Stalemate()
     {
-        var parameters = new DialogParameters<AddScoreDialog>();
+        var parameters = new DialogParameters<StalemateDialog>();
         var options = new DialogOptions { CloseOnEscapeKey = true };
         await DialogService.ShowAsync<StalemateDialog>("Score Stalemate", parameters, options);
     }


### PR DESCRIPTION
## Summary
- Fixes copy-paste bug in `Pages/Games/Mu.razor.cs` where `Stalemate()` method was using `DialogParameters<AddScoreDialog>` instead of `DialogParameters<StalemateDialog>`
- This type mismatch could cause issues if parameters are added to the dialog in the future

Fixes #20