### PR TITLE
ci: add CI workflow for pull request build verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '10.0.x'
+
+    - name: Build
+      run: dotnet build -c Release


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on pull requests targeting `main`
- The workflow checks out the code, sets up .NET 10, and runs `dotnet build -c Release` to verify the project compiles
- Gives PR status checks visibility so builds are verified before merging

Closes #40