### PR TITLE
fix: rename ReduceSplitGameState to ReduceYahtzeeGameState in Yahtzee reducer

### DIFF
--- a/Client/Store/Games/Yahtzee/Reducers.cs
+++ b/Client/Store/Games/Yahtzee/Reducers.cs
@@ -5,7 +5,7 @@ namespace BlazorScoreCards.Client.Store.Games.Yahtzee;
 public static class Reducers
 {
     [ReducerMethod]
-    public static YahtzeeGameState ReduceSplitGameState(YahtzeeGameState state, LoadScoresAction action)
+    public static YahtzeeGameState ReduceYahtzeeGameState(YahtzeeGameState state, LoadScoresAction action)
     {
         return state with { IsLoading = false, Scores = action.Scores };
     }


### PR DESCRIPTION
## Summary
- Fixes copy-paste naming error in `Client/Store/Games/Yahtzee/Reducers.cs` where the reducer method was incorrectly named `ReduceSplitGameState` instead of `ReduceYahtzeeGameState`
- No behavioral change — Fluxor resolves reducers by parameter types, not method names

Resolves #26