### PR TITLE
fix: remove redundant double-assignment in Qwixx Effects.cs

### DIFF
--- a/Client/Store/Games/Qwixx/Effects.cs
+++ b/Client/Store/Games/Qwixx/Effects.cs
@@ -85,7 +85,7 @@ public class Effects
         var scores = await LoadScoresAsync();
 
         var newIsLocked = new Dictionary<QwixxRanks, bool>(scores.IsLocked);
-        newIsLocked[action.Rank] = newIsLocked[action.Rank] = true;
+        newIsLocked[action.Rank] = true;
 
         scores = scores with { IsLocked = newIsLocked };
 
@@ -98,7 +98,7 @@ public class Effects
         var scores = await LoadScoresAsync();
 
         var newIsLocked = new Dictionary<QwixxRanks, bool>(scores.IsLocked);
-        newIsLocked[action.Rank] = newIsLocked[action.Rank] = false;
+        newIsLocked[action.Rank] = false;
 
         scores = scores with { IsLocked = newIsLocked };
 


### PR DESCRIPTION
## Summary

- Removed redundant self-assignment pattern in `Client/Store/Games/Qwixx/Effects.cs` at lines 88 and 101
- Changed `newIsLocked[action.Rank] = newIsLocked[action.Rank] = true;` to `newIsLocked[action.Rank] = true;`
- Changed `newIsLocked[action.Rank] = newIsLocked[action.Rank] = false;` to `newIsLocked[action.Rank] = false;`

## Details

The double-assignment was a copy-paste error that assigned the same value twice in a single expression. While functionally harmless, it was confusing to read. This PR simplifies both occurrences to single assignments.

Closes #7