### PR TITLE
fix: change HandleKeyDown return type from Task<bool> to Task in Generic AddScoreDialog

### DIFF
--- a/Components/Games/Generic/AddScoreDialog.razor.cs
+++ b/Components/Games/Generic/AddScoreDialog.razor.cs
@@ -37,14 +37,11 @@ public partial class AddScoreDialog
         }
     }
 
-    private async Task<bool> HandleKeyDown(KeyboardEventArgs e)
+    private async Task HandleKeyDown(KeyboardEventArgs e)
     {
         if (string.Equals(e.Key, "Enter", StringComparison.OrdinalIgnoreCase))
         {
             await UpdateScore();
-            return false;
         }
-
-        return true;
     }
 }


### PR DESCRIPTION
## Summary

- Changed `HandleKeyDown` return type from `Task<bool>` to `Task` in `Components/Games/Generic/AddScoreDialog.razor.cs`
- Removed the unused boolean return values (`return false` and `return true`)

## Why

Blazor's `@onkeydown` event callback expects `Task` (or `void`), not `Task<bool>`. The boolean return values were silently ignored and misleadingly suggested the method was trying to control event propagation, which doesn't work this way in Blazor.

Closes #32