### PR TITLE
fix: update outdated GitHub Actions to current versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-dotnet@v4
       with:
@@ -21,10 +21,7 @@ jobs:
       run: dotnet publish -c Release
 
     - name: Rewrite base href
-      uses: SteveSandersonMS/ghaction-rewrite-base-href@v1
-      with:
-        html_path: ${{ env.PUBLISH_DIR }}/index.html
-        base_href: /BlazorScoreCards/
+      run: sed -i 's|<base href="/" />|<base href="/BlazorScoreCards/" />|' ${{ env.PUBLISH_DIR }}/index.html
 
     # copy index.html to 404.html to serve the same file when a file is not found
     - name: copy index.html to 404.html
@@ -32,7 +29,7 @@ jobs:
 
     - name: GitHub Pages
       if: success()
-      uses: crazy-max/ghaction-github-pages@v1.5.1
+      uses: crazy-max/ghaction-github-pages@v4
       with:
         target_branch: gh-pages
         build_dir: ${{ env.PUBLISH_DIR }}


### PR DESCRIPTION
## Summary

Fixes #28

Updates the CI/CD workflow in `.github/workflows/main.yml` to use current, maintained GitHub Actions versions, addressing security and functionality concerns.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v2 (Node 12, deprecated) | v4 (Node 20) |
| `SteveSandersonMS/ghaction-rewrite-base-href` | v1 (unmaintained) | Replaced with `sed` command |
| `crazy-max/ghaction-github-pages` | v1.5.1 | v4 |

### Security improvements
- Eliminates dependency on deprecated Node 12 runtime (`actions/checkout@v2`)
- Updates to action versions that receive active security patches
- Removes dependency on an unmaintained third-party action

### Functional improvements
- The base href rewrite is now a simple `sed` command, removing the dependency on the unmaintained `SteveSandersonMS/ghaction-rewrite-base-href` action
- All actions now use supported Node.js runtimes