### PR TITLE
chore: remove unnecessary FluxorComponent inheritance from components without IState

### DIFF
--- a/Components/Games/Generic/ScoreCard.razor
+++ b/Components/Games/Generic/ScoreCard.razor
@@ -1,6 +1,4 @@
-﻿@inherits Fluxor.Blazor.Web.Components.FluxorComponent
-
-<MudPaper Class="pa-5">
+﻿<MudPaper Class="pa-5">
     <MudText Class="pb-2" Typo="Typo.h5">@PlayerName: @Score</MudText>
     <MudDivider Class="pb-2"/>
     <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="AddScore" Disabled="DisableButtons">Add Score</MudButton>

--- a/Components/Games/MilleBornes/AddScoreDialog.razor
+++ b/Components/Games/MilleBornes/AddScoreDialog.razor
@@ -1,6 +1,4 @@
-﻿@inherits Fluxor.Blazor.Web.Components.FluxorComponent
-
-<MudDialog>
+﻿<MudDialog>
     <DialogContent>
         <MudSlider Step="25" Min="0" Max="1000" TickMarks="true" TickMarkLabels="TickLabels" @bind-Value="@Distance">Distance: @Distance</MudSlider>
 

--- a/Components/Games/MilleBornes/ScoreCard.razor
+++ b/Components/Games/MilleBornes/ScoreCard.razor
@@ -1,6 +1,4 @@
-﻿@inherits Fluxor.Blazor.Web.Components.FluxorComponent
-
-<MudPaper Class="pa-5">
+﻿<MudPaper Class="pa-5">
     <MudText Class="pb-2" Typo="Typo.h5">@PlayerName: @Score</MudText>
     <MudDivider Class="pb-2"/>
     <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="AddScore" Disabled="DisableButtons">Add Score</MudButton>

--- a/Components/Games/SevenWonders/ScoreCard.razor
+++ b/Components/Games/SevenWonders/ScoreCard.razor
@@ -1,6 +1,4 @@
-﻿@inherits Fluxor.Blazor.Web.Components.FluxorComponent
-
-<MudPaper Class="pa-5">
+﻿<MudPaper Class="pa-5">
     <MudText Class="pb-2" Typo="Typo.h5">@PlayerName: @Score</MudText>
     <MudDivider Class="pb-2"/>
     <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="AddScore">Add Score</MudButton>


### PR DESCRIPTION
## Summary

- Remove `@inherits Fluxor.Blazor.Web.Components.FluxorComponent` from four components that do not inject any `IState<T>` properties, eliminating unnecessary Fluxor state change subscriptions and re-render overhead.

## Affected Components

- `Components/Games/SevenWonders/ScoreCard.razor`
- `Components/Games/Generic/ScoreCard.razor`
- `Components/Games/MilleBornes/ScoreCard.razor`
- `Components/Games/MilleBornes/AddScoreDialog.razor`

## Details

`FluxorComponent` subscribes to Fluxor state change notifications and triggers re-renders. These four components only use `IDispatcher` and/or `IDialogService` — they don't consume any `IState<T>`, so the `FluxorComponent` base class adds overhead with no benefit.

Closes #34