### PR TITLE
chore: standardize reducer method naming to Reduce{FeatureName}State pattern

### DIFF
--- a/Client/Store/Games/Wizard/Reducers.cs
+++ b/Client/Store/Games/Wizard/Reducers.cs
@@ -5,7 +5,7 @@ namespace BlazorScoreCards.Client.Store.Games.Wizard;
 public static class Reducers
 {
     [ReducerMethod]
-    public static WizardGameState ReduceLoadScores(WizardGameState state, LoadScoresAction action)
+    public static WizardGameState ReduceWizardGameState(WizardGameState state, LoadScoresAction action)
     {
         return state with { IsLoading = false, Hands = action.Hands };
     }

--- a/Client/Store/NavMenu/Reducers.cs
+++ b/Client/Store/NavMenu/Reducers.cs
@@ -5,10 +5,10 @@ namespace BlazorScoreCards.Client.Store.NavMenu;
 public static class Reducers
 {
     [ReducerMethod]
-    public static NavMenuState ReduceNavMenu(NavMenuState state, ToggleDrawerOpenAction action) =>
+    public static NavMenuState ReduceNavMenuState(NavMenuState state, ToggleDrawerOpenAction action) =>
         state with { DrawerOpen = !state.DrawerOpen };
 
     [ReducerMethod]
-    public static NavMenuState ReduceNavMenu(NavMenuState state, SetDrawerOpenAction action) =>
+    public static NavMenuState ReduceNavMenuState(NavMenuState state, SetDrawerOpenAction action) =>
         state with { DrawerOpen = action.NewState };
 }

--- a/Client/Store/Theme/Reducers.cs
+++ b/Client/Store/Theme/Reducers.cs
@@ -5,6 +5,6 @@ namespace BlazorScoreCards.Client.Store.Theme;
 public static class Reducers
 {
     [ReducerMethod]
-    public static ThemeState ReduceDarkMode(ThemeState state, SetDarkModeCompleteAction action) =>
+    public static ThemeState ReduceThemeState(ThemeState state, SetDarkModeCompleteAction action) =>
         state with { IsDarkMode = action.IsDarkMode };
 }


### PR DESCRIPTION
## Summary

- Renames inconsistent reducer methods across three store files to follow the established `Reduce{FeatureName}State` naming convention
- No functional changes — Fluxor resolves reducers by parameter types, not method names

## Changes

| File | Before | After |
|------|--------|-------|
| `Client/Store/Games/Wizard/Reducers.cs` | `ReduceLoadScores` | `ReduceWizardGameState` |
| `Client/Store/NavMenu/Reducers.cs` | `ReduceNavMenu` | `ReduceNavMenuState` |
| `Client/Store/Theme/Reducers.cs` | `ReduceDarkMode` | `ReduceThemeState` |

All other reducer files (`Players`, `Orientation`, `Generic`, `Split`, `SevenWonders`, `Qwixx`, `MilleBornes`, `Mu`, `Yahtzee`) already follow this convention.

Closes #35