### PR TITLE
fix: validate LastBidder selection in StalemateDialog.IsOkDisabled()

### DIFF
--- a/Components/Games/Mu/StalemateDialog.razor.cs
+++ b/Components/Games/Mu/StalemateDialog.razor.cs
@@ -101,6 +101,11 @@ public partial class StalemateDialog
             return true;
         }
 
+        if (_HighestBidder.Count == 0)
+        {
+            return true;
+        }
+
         return false;
     }
 }

--- a/Components/Games/Mu/StalemateDialog.razor.cs
+++ b/Components/Games/Mu/StalemateDialog.razor.cs
@@ -96,6 +96,11 @@ public partial class StalemateDialog
 
     private bool IsOkDisabled()
     {
+        if (string.IsNullOrEmpty(_LastBidder))
+        {
+            return true;
+        }
+
         return false;
     }
 }


### PR DESCRIPTION
## Summary

- **Bug**: `StalemateDialog.IsOkDisabled()` always returned `false`, allowing users to submit a stalemate without selecting the "On Hook" (LastBidder) player
- **Fix**: Added validation to disable the Ok button when `_LastBidder` is empty, consistent with `AddScoreDialog`'s validation pattern

## Details

Without this fix, submitting a stalemate with no LastBidder selected would result in a no-op — `_LastBidder` defaults to `string.Empty`, so `UpdateScore()` would give no penalty to anyone and just close the dialog.

The fix checks `string.IsNullOrEmpty(_LastBidder)` and returns `true` (disabled) if no player is selected, matching the same validation approach used in `AddScoreDialog.IsOkDisabled()`.

Closes #24