### PR TITLE
fix: Split game rank cycling uses % 5 instead of % 6, making 200-point bonus unreachable

### DIFF
--- a/Client/Store/Games/Split/Effects.cs
+++ b/Client/Store/Games/Split/Effects.cs
@@ -30,7 +30,7 @@ public class Effects
         var scores = await LoadScoresAsync();
 
         var newScores = new Dictionary<SplitRanks, int>(scores.Scores);
-        newScores[action.Rank] = (newScores[action.Rank] + 1) % 5;
+        newScores[action.Rank] = (newScores[action.Rank] + 1) % 6;
 
         scores = scores with { Scores = newScores };
 

--- a/Components/Games/Split/RankRow.razor
+++ b/Components/Games/Split/RankRow.razor
@@ -10,4 +10,5 @@
     <MudAvatar Variant="Variant.Filled" Color="@GetColor(2)">@_ValueMap[Rank][2]</MudAvatar>
     <MudAvatar Variant="Variant.Filled" Color="@GetColor(3)">@_ValueMap[Rank][3]</MudAvatar>
     <MudAvatar Variant="Variant.Filled" Color="@GetColor(4)">@_ValueMap[Rank][4]</MudAvatar>
+    <MudAvatar Variant="Variant.Filled" Color="@GetColor(5)">@_ValueMap[Rank][5]</MudAvatar>
 </MudItem>


### PR DESCRIPTION
## Summary

- Fixed rank cycling modulo from `% 5` to `% 6` in `Client/Store/Games/Split/Effects.cs` so all 6 values (indices 0-5) are reachable, including the 200-point bonus at index 5.
- Added a 6th `MudAvatar` in `Components/Games/Split/RankRow.razor` to display the value at index 5 in the UI.

Fixes #18