### PR TITLE
fix: rename misleading 'players' variable to 'savedScores' in LoadScoresAsync

### DIFF
--- a/Client/Store/Games/Generic/Effects.cs
+++ b/Client/Store/Games/Generic/Effects.cs
@@ -52,13 +52,13 @@ public class Effects
 
     private async Task<Dictionary<string, int>> LoadScoresAsync()
     {
-        var players = await _LocalStorageService.GetItemAsync<IReadOnlyDictionary<string,  int>>(ScoresKey);
-        if (players == null)
+        var savedScores = await _LocalStorageService.GetItemAsync<IReadOnlyDictionary<string,  int>>(ScoresKey);
+        if (savedScores == null)
         {
-            players = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            savedScores = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         }
 
-        return new Dictionary<string, int>(players, StringComparer.OrdinalIgnoreCase);
+        return new Dictionary<string, int>(savedScores, StringComparer.OrdinalIgnoreCase);
     }
 
     private async Task UpdateAndDispatchAsync(IDispatcher dispatcher, IReadOnlyDictionary<string, int> scores)

--- a/Client/Store/Games/MilleBornes/Effects.cs
+++ b/Client/Store/Games/MilleBornes/Effects.cs
@@ -52,13 +52,13 @@ public class Effects
 
     private async Task<Dictionary<string, int>> LoadScoresAsync()
     {
-        var players = await _LocalStorageService.GetItemAsync<IReadOnlyDictionary<string,  int>>(ScoresKey);
-        if (players == null)
+        var savedScores = await _LocalStorageService.GetItemAsync<IReadOnlyDictionary<string,  int>>(ScoresKey);
+        if (savedScores == null)
         {
-            players = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            savedScores = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         }
 
-        return new Dictionary<string, int>(players, StringComparer.OrdinalIgnoreCase);
+        return new Dictionary<string, int>(savedScores, StringComparer.OrdinalIgnoreCase);
     }
 
     private async Task UpdateAndDispatchAsync(IDispatcher dispatcher, IReadOnlyDictionary<string, int> scores)

--- a/Client/Store/Games/Mu/Effects.cs
+++ b/Client/Store/Games/Mu/Effects.cs
@@ -55,13 +55,13 @@ public class Effects
 
     private async Task<Dictionary<string, int>> LoadScoresAsync()
     {
-        var players = await _LocalStorageService.GetItemAsync<IReadOnlyDictionary<string, int>>(ScoresKey);
-        if (players == null)
+        var savedScores = await _LocalStorageService.GetItemAsync<IReadOnlyDictionary<string, int>>(ScoresKey);
+        if (savedScores == null)
         {
-            players = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            savedScores = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         }
 
-        return new Dictionary<string, int>(players, StringComparer.OrdinalIgnoreCase);
+        return new Dictionary<string, int>(savedScores, StringComparer.OrdinalIgnoreCase);
     }
 
     private async Task UpdateAndDispatchAsync(IDispatcher dispatcher, IReadOnlyDictionary<string, int> scores)

--- a/Client/Store/Games/SevenWonders/Effects.cs
+++ b/Client/Store/Games/SevenWonders/Effects.cs
@@ -52,13 +52,13 @@ public class Effects
 
     private async Task<Dictionary<string, int>> LoadScoresAsync()
     {
-        var players = await _LocalStorageService.GetItemAsync<IReadOnlyDictionary<string,  int>>(ScoresKey);
-        if (players == null)
+        var savedScores = await _LocalStorageService.GetItemAsync<IReadOnlyDictionary<string,  int>>(ScoresKey);
+        if (savedScores == null)
         {
-            players = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            savedScores = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         }
 
-        return new Dictionary<string, int>(players, StringComparer.OrdinalIgnoreCase);
+        return new Dictionary<string, int>(savedScores, StringComparer.OrdinalIgnoreCase);
     }
 
     private async Task UpdateAndDispatchAsync(IDispatcher dispatcher, IReadOnlyDictionary<string, int> scores)


### PR DESCRIPTION
## Summary

- Renames the misleading `players` variable to `savedScores` in the `LoadScoresAsync()` method across all four game store `Effects.cs` files
- The variable holds score data loaded from local storage, not player information — the new name accurately reflects its contents

## Files Changed

- `Client/Store/Games/Generic/Effects.cs`
- `Client/Store/Games/SevenWonders/Effects.cs`
- `Client/Store/Games/MilleBornes/Effects.cs`
- `Client/Store/Games/Mu/Effects.cs`

Closes #14