### PR TITLE
chore: update outdated GitHub Actions to current versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-dotnet@v4
       with:
@@ -32,7 +32,7 @@ jobs:
 
     - name: GitHub Pages
       if: success()
-      uses: crazy-max/ghaction-github-pages@v1.5.1
+      uses: crazy-max/ghaction-github-pages@v4
       with:
         target_branch: gh-pages
         build_dir: ${{ env.PUBLISH_DIR }}


### PR DESCRIPTION
## Summary

- Update `actions/checkout` from v2 to v4
- Update `crazy-max/ghaction-github-pages` from v1.5.1 to v4

## Motivation

Using old action versions means missing out on security patches, performance improvements, and Node.js runtime updates. GitHub has deprecated Node 12 and Node 16 runners, so these updates ensure the workflow continues to function correctly.

## Changes

- `.github/workflows/main.yml`: Updated two action version references

## Files Affected

- `.github/workflows/main.yml`

Closes #12