### PR TITLE
fix: dispose DotNetObjectReference in UpdateAvailableDetector to prevent memory leak

### DIFF
--- a/Shared/UpdateAvailableDetector.razor
+++ b/Shared/UpdateAvailableDetector.razor
@@ -1,8 +1,11 @@
 ﻿@inject IJSRuntime _jsRuntime
 @inject ISnackbar Snackbar
 @inject NavigationManager NavigationManager
+@implements IDisposable
 
 @code {
+    private DotNetObjectReference<UpdateAvailableDetector>? _objRef;
+
     protected override async Task OnInitializedAsync()
     {
         await RegisterForUpdateAvailableNotification();
@@ -10,9 +13,10 @@
 
     private async Task RegisterForUpdateAvailableNotification()
     {
+        _objRef = DotNetObjectReference.Create(this);
         await _jsRuntime.InvokeAsync<object>(
             identifier: "registerForUpdateAvailableNotification",
-            DotNetObjectReference.Create(this),
+            _objRef,
             nameof(OnUpdateAvailable));
     }
 
@@ -31,5 +35,10 @@
         });
 
         return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _objRef?.Dispose();
     }
 }


### PR DESCRIPTION
## Summary

- Store the `DotNetObjectReference` in a private field instead of creating an anonymous instance
- Implement `IDisposable` on `UpdateAvailableDetector` component
- Dispose the `DotNetObjectReference` in the `Dispose` method to prevent the .NET object from being pinned in memory indefinitely

## Changes

**`Shared/UpdateAvailableDetector.razor`**:
- Added `@implements IDisposable` directive
- Added `_objRef` field of type `DotNetObjectReference<UpdateAvailableDetector>?`
- Store the reference created via `DotNetObjectReference.Create(this)` in `_objRef`
- Pass `_objRef` to JS interop instead of an anonymous inline reference
- Added `Dispose()` method that calls `_objRef?.Dispose()`

Closes #4