### PR TITLE
fix: resolve service worker path relative to document base URI

### DIFF
--- a/wwwroot/sw-registrator.js
+++ b/wwwroot/sw-registrator.js
@@ -6,7 +6,7 @@ window.updateAvailable = new Promise((resolve, reject) => {
         return;
     }
 
-    navigator.serviceWorker.register('/service-worker.js')
+    navigator.serviceWorker.register(new URL('service-worker.js', document.baseURI).href)
         .then(registration => {
             console.info(`Service worker registration successful (scope: ${registration.scope})`);
 


### PR DESCRIPTION
## Summary

Fixes the service worker registration path to work correctly when deployed under a subdirectory (e.g., GitHub Pages at `/BlazorScoreCards/`).

## Changes

- **`wwwroot/sw-registrator.js:9`**: Replaced hardcoded absolute path `'/service-worker.js'` with `new URL('service-worker.js', document.baseURI).href` to resolve the service worker path relative to the document's base URI.

## Problem

The hardcoded absolute path `/service-worker.js` caused the browser to look for the service worker at the site root, which fails when the app is deployed under a subdirectory like `/BlazorScoreCards/`.

## Solution

Using `new URL('service-worker.js', document.baseURI).href` resolves the path against the `<base>` tag set in `index.html`, producing the correct path (e.g., `/BlazorScoreCards/service-worker.js`) regardless of deployment location.

Closes #2