### PR TITLE
fix: document why AllowUnsafeBlocks is required (#9)

### DIFF
--- a/BlazorScoreCards.csproj
+++ b/BlazorScoreCards.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
+        <!-- Required by JSImport/JSExport interop attributes (see App.razor.cs) -->
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <BlazorCacheBootResources>false</BlazorCacheBootResources>
         <DisableGitAutoCRLFInPublishOutput>true</DisableGitAutoCRLFInPublishOutput>


### PR DESCRIPTION
## Summary

Closes #9

**Finding:** `AllowUnsafeBlocks` **cannot be removed** — it is required by the project.

### Investigation

The issue reported that `AllowUnsafeBlocks` was enabled without any `unsafe` code in the codebase. However, upon investigation:

1. `App.razor.cs` uses `[JSImport]` (lines 30, 33) and `[JSExport]` (line 36) attributes for Blazor WebAssembly JS interop
2. These attributes require `AllowUnsafeBlocks` because the .NET source generators produce `unsafe` code internally (`SYSLIB1074` / `SYSLIB1075`)
3. Removing the setting causes 5 build errors

The initial grep for `unsafe` missed this because the `unsafe` keyword only appears in source-generated code (under `obj/`), not in user-written source files.

### Changes

- Added an XML comment in `BlazorScoreCards.csproj` above `AllowUnsafeBlocks` explaining why it is required, to prevent this from being flagged again in the future

### Verification

- Build passes with the comment added
- Build **fails** if `AllowUnsafeBlocks` is removed (confirmed)