### PR TITLE
feat: support system theme preference

### DIFF
--- a/Client/Store/Theme/Effects.cs
+++ b/Client/Store/Theme/Effects.cs
@@ -1,4 +1,4 @@
-﻿using Blazored.LocalStorage;
+using Blazored.LocalStorage;
 using Fluxor;
 using System.Threading.Tasks;
 
@@ -6,7 +6,7 @@ namespace BlazorScoreCards.Client.Store.Theme;
 
 public class Effects
 {
-    private const string DarkModeKey = "darkmode";
+    private const string ThemePreferenceKey = "darkmode";
 
     private readonly ILocalStorageService _LocalStorageService;
 
@@ -18,20 +18,28 @@ public class Effects
     [EffectMethod]
     public async Task EffectThemeState(LoadInitialStateAction action, IDispatcher dispatcher)
     {
-        var current = true;
-        var currentValue = await _LocalStorageService.GetItemAsStringAsync(DarkModeKey);
+        var current = ThemePreference.System;
+        var currentValue = await _LocalStorageService.GetItemAsStringAsync(ThemePreferenceKey);
+
         if (!string.IsNullOrWhiteSpace(currentValue))
         {
-            bool.TryParse(currentValue, out current);
+            if (System.Enum.TryParse<ThemePreference>(currentValue, true, out var currentPreference))
+            {
+                current = currentPreference;
+            }
+            else if (bool.TryParse(currentValue, out var isDarkMode))
+            {
+                current = isDarkMode ? ThemePreference.Dark : ThemePreference.Light;
+            }
         }
 
-        dispatcher.Dispatch(new SetDarkModeCompleteAction(current));
+        dispatcher.Dispatch(new SetThemePreferenceCompleteAction(current));
     }
 
     [EffectMethod]
-    public async Task EffectThemeState(SetDarkModeAction action, IDispatcher dispatcher)
+    public async Task EffectThemeState(SetThemePreferenceAction action, IDispatcher dispatcher)
     {
-        await _LocalStorageService.SetItemAsStringAsync(DarkModeKey, action.IsDarkMode.ToString());
-        dispatcher.Dispatch(new SetDarkModeCompleteAction(action.IsDarkMode));
+        await _LocalStorageService.SetItemAsStringAsync(ThemePreferenceKey, action.Preference.ToString());
+        dispatcher.Dispatch(new SetThemePreferenceCompleteAction(action.Preference));
     }
 }

--- a/Client/Store/Theme/Reducers.cs
+++ b/Client/Store/Theme/Reducers.cs
@@ -1,10 +1,10 @@
-﻿using Fluxor;
+using Fluxor;
 
 namespace BlazorScoreCards.Client.Store.Theme;
 
 public static class Reducers
 {
     [ReducerMethod]
-    public static ThemeState ReduceThemeState(ThemeState state, SetDarkModeCompleteAction action) =>
-        state with { IsDarkMode = action.IsDarkMode };
+    public static ThemeState ReduceThemeState(ThemeState state, SetThemePreferenceCompleteAction action) =>
+        state with { Preference = action.Preference };
 }

--- a/Client/Store/Theme/SetDarkModeAction.cs
+++ b/Client/Store/Theme/SetDarkModeAction.cs
@@ -1,3 +1,0 @@
-﻿namespace BlazorScoreCards.Client.Store.Theme;
-
-public record SetDarkModeAction(bool IsDarkMode);

--- a/Client/Store/Theme/SetDarkModeCompleteAction.cs
+++ b/Client/Store/Theme/SetDarkModeCompleteAction.cs
@@ -1,3 +1,0 @@
-﻿namespace BlazorScoreCards.Client.Store.Theme;
-
-public record SetDarkModeCompleteAction(bool IsDarkMode);

--- a/Client/Store/Theme/SetThemePreferenceAction.cs
+++ b/Client/Store/Theme/SetThemePreferenceAction.cs
@@ -1,0 +1,3 @@
+namespace BlazorScoreCards.Client.Store.Theme;
+
+public record SetThemePreferenceAction(ThemePreference Preference);

--- a/Client/Store/Theme/SetThemePreferenceCompleteAction.cs
+++ b/Client/Store/Theme/SetThemePreferenceCompleteAction.cs
@@ -1,0 +1,3 @@
+namespace BlazorScoreCards.Client.Store.Theme;
+
+public record SetThemePreferenceCompleteAction(ThemePreference Preference);

--- a/Client/Store/Theme/ThemeState.cs
+++ b/Client/Store/Theme/ThemeState.cs
@@ -1,10 +1,16 @@
-﻿using Fluxor;
+using Fluxor;
 
 namespace BlazorScoreCards.Client.Store.Theme;
 
-[FeatureState(CreateInitialStateMethodName = nameof(CreateInitialState))]
-public record ThemeState(bool IsDarkMode)
+public enum ThemePreference
 {
-    public static ThemeState CreateInitialState() => new(true);
+    System,
+    Light,
+    Dark,
 }
 
+[FeatureState(CreateInitialStateMethodName = nameof(CreateInitialState))]
+public record ThemeState(ThemePreference Preference)
+{
+    public static ThemeState CreateInitialState() => new(ThemePreference.System);
+}

--- a/Shared/MainLayout.razor
+++ b/Shared/MainLayout.razor
@@ -1,6 +1,10 @@
-﻿@inherits Fluxor.Blazor.Web.Components.FluxorLayout
+@inherits Fluxor.Blazor.Web.Components.FluxorLayout
 
-<MudThemeProvider Theme="@DefaultTheme" IsDarkMode="@ThemeState.Value.IsDarkMode" />
+<MudThemeProvider @ref="_themeProvider"
+                  Theme="@DefaultTheme"
+                  IsDarkMode="@CurrentIsDarkMode"
+                  IsDarkModeChanged="@OnDarkModeChanged"
+                  ObserveSystemDarkModeChange="@UseSystemTheme" />
 <MudDialogProvider />
 <MudSnackbarProvider />
 <MudPopoverProvider />

--- a/Shared/MainLayout.razor.cs
+++ b/Shared/MainLayout.razor.cs
@@ -1,7 +1,8 @@
-﻿using BlazorScoreCards.Client.Store.Theme;
+using BlazorScoreCards.Client.Store.Theme;
 using Fluxor;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
+using System.Threading.Tasks;
 
 namespace BlazorScoreCards.Shared;
 
@@ -9,6 +10,19 @@ public partial class MainLayout
 {
     [Inject]
     private IState<ThemeState> ThemeState { get; set; } = default!;
+
+    private MudThemeProvider? _themeProvider;
+    private ThemePreference _lastThemePreference = ThemePreference.System;
+    private bool _systemIsDarkMode = true;
+
+    private bool UseSystemTheme => ThemeState.Value.Preference == ThemePreference.System;
+
+    private bool CurrentIsDarkMode => ThemeState.Value.Preference switch
+    {
+        ThemePreference.Dark => true,
+        ThemePreference.Light => false,
+        _ => _systemIsDarkMode,
+    };
 
     private static readonly LayoutProperties _DefaultLayoutProperties = new LayoutProperties()
     {
@@ -19,4 +33,33 @@ public partial class MainLayout
     {
         LayoutProperties = _DefaultLayoutProperties
     };
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_themeProvider is null)
+        {
+            return;
+        }
+
+        if (firstRender || _lastThemePreference != ThemeState.Value.Preference && UseSystemTheme)
+        {
+            _systemIsDarkMode = await _themeProvider.GetSystemDarkModeAsync();
+            _lastThemePreference = ThemeState.Value.Preference;
+            StateHasChanged();
+            return;
+        }
+
+        _lastThemePreference = ThemeState.Value.Preference;
+    }
+
+    private Task OnDarkModeChanged(bool isDarkMode)
+    {
+        if (UseSystemTheme && _systemIsDarkMode != isDarkMode)
+        {
+            _systemIsDarkMode = isDarkMode;
+            StateHasChanged();
+        }
+
+        return Task.CompletedTask;
+    }
 }

--- a/Shared/NavBar.razor
+++ b/Shared/NavBar.razor
@@ -18,7 +18,7 @@
         <MudNavGroup Title="Settings" Icon="@Icons.Material.Filled.Settings" Expanded="true">
             <MudNavLink Href="settings/players" Match="NavLinkMatch.Prefix">Players</MudNavLink>
             <div class="mud-nav-item">
-                <div class="mud-nav-link mud-nav-link-disabled">
+                <div class="mud-nav-link">
                     <MudSelect T="ThemePreference"
                                Label="Theme"
                                Value="@ThemeState.Value.Preference"

--- a/Shared/NavBar.razor
+++ b/Shared/NavBar.razor
@@ -1,4 +1,5 @@
-﻿@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+﻿@using BlazorScoreCards.Client.Store.Theme
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <MudDrawer Open="@NavBarState.Value.DrawerOpen" OpenChanged="@OpenChanged" ClipMode="DrawerClipMode.Docked" Anchor="Anchor.Right">
     <MudNavMenu>
@@ -17,8 +18,19 @@
         <MudNavGroup Title="Settings" Icon="@Icons.Material.Filled.Settings" Expanded="true">
             <MudNavLink Href="settings/players" Match="NavLinkMatch.Prefix">Players</MudNavLink>
             <div class="mud-nav-item">
-                <div class="mud-nav-link">
-                    <MudSwitch T="bool" Value="@ThemeState.Value.IsDarkMode" Color="Color.Primary" ValueChanged="@DarkModeCheckedChanged">Dark Mode</MudSwitch>
+                <div class="mud-nav-link mud-nav-link-disabled">
+                    <MudSelect T="ThemePreference"
+                               Label="Theme"
+                               Value="@ThemeState.Value.Preference"
+                               ValueChanged="@ThemePreferenceChanged"
+                               Dense="true"
+                               Margin="Margin.Dense"
+                               Variant="Variant.Text"
+                               FullWidth="true">
+                        <MudSelectItem T="ThemePreference" Value="@ThemePreference.System">System</MudSelectItem>
+                        <MudSelectItem T="ThemePreference" Value="@ThemePreference.Light">Light</MudSelectItem>
+                        <MudSelectItem T="ThemePreference" Value="@ThemePreference.Dark">Dark</MudSelectItem>
+                    </MudSelect>
                 </div>
             </div>
         </MudNavGroup>

--- a/Shared/NavBar.razor.cs
+++ b/Shared/NavBar.razor.cs
@@ -25,8 +25,8 @@ public partial class NavBar
         }
     }
 
-    private void DarkModeCheckedChanged(bool newValue)
+    private void ThemePreferenceChanged(ThemePreference newValue)
     {
-        Dispatcher.Dispatch(new SetDarkModeAction(newValue));
+        Dispatcher.Dispatch(new SetThemePreferenceAction(newValue));
     }
 }


### PR DESCRIPTION
## Summary
- replace the dark mode toggle with light, dark, and system theme options
- persist the selected theme preference while keeping old boolean local storage values compatible
- follow the browser system theme when the system option is selected

## Validation
- `dotnet build`