### PR TITLE
chore: update MudBlazor to 9.1.0

### DIFF
--- a/BlazorScoreCards.csproj
+++ b/BlazorScoreCards.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="Fluxor.Blazor.Web" Version="6.9.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" PrivateAssets="all" />
-        <PackageReference Include="MudBlazor" Version="9.0.0" />
+        <PackageReference Include="MudBlazor" Version="9.1.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Closes #62

## Summary
- update the MudBlazor package reference from 9.0.0 to 9.1.0
- verify the Blazor WebAssembly app still builds cleanly after the upgrade