### PR TITLE
chore: upgrade Blazored.LocalStorage to Blazor.Storage

### DIFF
--- a/BlazorScoreCards.csproj
+++ b/BlazorScoreCards.csproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
+        <PackageReference Include="Blazor.Storage" Version="5.0.0" />
         <PackageReference Include="Fluxor.Blazor.Web" Version="6.9.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" PrivateAssets="all" />

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ The app will be available at the URL shown in the console output (typically `htt
 - [Blazor WebAssembly](https://learn.microsoft.com/aspnet/core/blazor/) (.NET 10)
 - [MudBlazor](https://mudblazor.com/) for Material Design UI components
 - [Fluxor](https://github.com/mrpmorris/Fluxor) for Redux-style state management
-- [Blazored.LocalStorage](https://github.com/Blazored/LocalStorage) for browser local storage
+- [Blazor.Storage](https://github.com/mmsoftpl/Blazor.Storage) for browser local storage


### PR DESCRIPTION
## Summary
- replace the archived `Blazored.LocalStorage` package with `Blazor.Storage` 5.0.0
- keep the existing local storage integration unchanged because the new package preserves the same `Blazored.LocalStorage` API surface used by the app
- update the project README to point at the maintained package repository

## Verification
- `dotnet build`

Closes #63