### PR TITLE
chore: upgrade Blazor WebAssembly packages to 10.0.5

### DIFF
--- a/BlazorScoreCards.csproj
+++ b/BlazorScoreCards.csproj
@@ -18,8 +18,8 @@
     <ItemGroup>
         <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
         <PackageReference Include="Fluxor.Blazor.Web" Version="6.9.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" PrivateAssets="all" />
         <PackageReference Include="MudBlazor" Version="9.1.0" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- upgrade `Microsoft.AspNetCore.Components.WebAssembly` to `10.0.5`
- upgrade `Microsoft.AspNetCore.Components.WebAssembly.DevServer` to `10.0.5`
- verify the app still builds successfully with `dotnet build`

Closes #65